### PR TITLE
Generic notifier created

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,2 @@
+[style]
+based_on_style = yapf


### PR DESCRIPTION
* Do not call notification interfaces directly - register those
  that you need and app engine would notify all registered
  instances when it is needed.
* yapf formatted maildirwatch.py