### PR TITLE
Do not show timestamp when running under systemd

### DIFF
--- a/maildirwatch.py
+++ b/maildirwatch.py
@@ -300,8 +300,11 @@ class App:
 
 
 def main():
-    logging.basicConfig(
-        level=logging.INFO, format='%(asctime)s [%(levelname)s] %(message)s')
+    if os.environ.get('INVOCATION_ID', False):
+        logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
+    else:
+        logging.basicConfig(
+            level=logging.INFO, format='%(asctime)s [%(levelname)s] %(message)s')
 
     argv = Gtk.init(sys.argv)
 


### PR DESCRIPTION
journald already adds the timestamp, so it's redundant in that case.

You could easily argue that the check for the variable should be moved into its own function if you were to have different logic based on how it's run in other places. This was just the quick and dirty.